### PR TITLE
Fix ac-library-rb gemspec bug by patching require_paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ RUN gem install -N \
     sorted_containers:1.1.0 \
     sorted_set:1.0.3 && \
     # Fix ac-library-rb gemspec bug (upstream issue: malformed require_paths)
-    sed -i 's/lib_helpers\\"/lib_helpers/g' /opt/ruby/lib/ruby/gems/3.4.0/specifications/ac-library-rb-1.2.0.gemspec
+    sed -i 's/lib_helpers\\"/lib_helpers/g' "$(gem environment gemdir)/specifications/ac-library-rb-1.2.0.gemspec"
 
 # Install Rust from official precompiled tarball
 ARG RUST_VERSION=1.87.0

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -128,7 +128,7 @@ RUN gem install -N \
     sorted_containers:1.1.0 \
     sorted_set:1.0.3 && \
     # Fix ac-library-rb gemspec bug (upstream issue: malformed require_paths)
-    sed -i 's/lib_helpers\\"/lib_helpers/g' /opt/ruby/lib/ruby/gems/3.4.0/specifications/ac-library-rb-1.2.0.gemspec
+    sed -i 's/lib_helpers\\"/lib_helpers/g' "$(gem environment gemdir)/specifications/ac-library-rb-1.2.0.gemspec"
 
 # Install Rust from official precompiled tarball
 ARG RUST_VERSION=1.87.0


### PR DESCRIPTION
## 🐛 問題

Ruby 3.4.5 にアップデート後、ac-library-rb gem が正しく require できない問題が発生していました。

```ruby
ruby -e "require 'ac-library-rb'; puts 'OK'"
# => LoadError: cannot load such file -- ac-library-rb
```

## 🔍 根本原因

ac-library-rb 1.2.0 の upstream gemspec ファイル自体に問題がありました：

```ruby
# 問題のある gemspec
spec.require_paths = %w[lib_lock lib_helpers"]
#                                          ^^^ 余分なバックスラッシュとダブルクォート
```

末尾の `lib_helpers\"` により、gemspec のパースが正常に行われず、gem が require できない状態になっていました。

## ✅ 対応方針

**採用した方法**: gem install 後に gemspec ファイルを自動修正

**理由**:
1. AtCoder TOML 整合性を維持（バージョン 1.2.0 を使用）
2. upstream の問題を回避しつつ、動作する環境を構築
3. 将来 upstream が修正されても影響を受けない

## 📝 実装内容

両 Dockerfile に以下の修正スクリプトを追加：

```bash
gem install -N ac-library-rb:1.2.0 && \
    # Fix ac-library-rb gemspec bug (upstream issue: malformed require_paths)
    sed -i 's/lib_helpers\\"/lib_helpers/g' /opt/ruby/lib/ruby/gems/3.4.0/specifications/ac-library-rb-1.2.0.gemspec
```

## 📦 影響範囲

- ✅ Dockerfile (Full 版)
- ✅ Dockerfile.lite (Lite 版)

## 🔗 関連情報

- Resolves #28
- Upstream リポジトリ: https://github.com/universato/ac-library-rb
- RubyGems: https://rubygems.org/gems/ac-library-rb/versions/1.2.0

## 📋 次のステップ

- [ ] upstream に Issue を報告
- [ ] CI ビルドの成功を確認