### PR TITLE
Fix CI runners to use ubuntu-24.04 for consistency

### DIFF
--- a/.github/workflows/build-staged.yml
+++ b/.github/workflows/build-staged.yml
@@ -162,7 +162,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
@@ -255,7 +255,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm


### PR DESCRIPTION
## 概要

CI runnerを `ubuntu-latest` から `ubuntu-24.04` に変更し、amd64とarm64の環境一貫性を向上させます。

## 変更内容

- build-lite job の runner を `ubuntu-latest` → `ubuntu-24.04` に変更
- build-full job の runner を `ubuntu-latest` → `ubuntu-24.04` に変更

## 効果

1. **一貫性の向上**: amd64とarm64で同じUbuntu 24.04を使用
2. **再現性の確保**: `ubuntu-latest` は将来的に26.04などに変わる可能性があるが、明示的なバージョン指定により長期的な再現性を確保
3. **コンテナとの整合性**: Dockerfileのベースイメージ (`ubuntu:24.04`) とrunner OSのバージョンが一致

## テスト

- ワークフロー定義ファイルの変更のみ
- CI実行時に自動的にテストされます

Resolves #38