### PR TITLE
Update CLAUDE.md with latest versions and container variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Docker container image specifically designed for AtCoder competitive programming. It provides a comprehensive development environment with multiple programming languages and their libraries optimized for competitive programming.
 
+## Container Variants
+
+This repository provides multiple container variants optimized for different use cases:
+
+- **Full Version** (`Dockerfile`): Complete environment with all languages and libraries
+  - Size: ~8-10GB
+  - Includes: All languages, scientific libraries (NumPy, SciPy, PyTorch), OR-Tools, Boost, etc.
+  - Best for: Complete competitive programming environment
+
+- **Lite Version** (`Dockerfile.lite`): Lightweight, optimized for CI/CD
+  - Size: ~3.86GB
+  - Includes: Core languages with essential libraries
+  - Architecture: Multi-stage build (builder + runtime)
+  - Best for: CI pipelines, quick testing
+
 ## Build Commands
 
 ```bash
-# Build the Docker image
+# Build the Full version
 docker build -t atcoder-container:latest .
+
+# Build the Lite version
+docker build -t atcoder-container:lite -f Dockerfile.lite .
 
 # Build with specific tag
 docker build -t atcoder-container:2025 .
@@ -18,47 +36,73 @@ docker build -t atcoder-container:2025 .
 
 ## Supported Languages and Versions
 
-The container includes the following languages (as of the latest Dockerfile):
-- **Python** 3.13.5 (with LTO and BOLT optimizations on x86_64)
-- **Node.js** 22.16.0
+The container includes the following languages (versions as of January 2025):
+
+### Full Version (Dockerfile)
+- **Python** 3.13.7 (with LTO and BOLT optimizations on x86_64)
+- **Node.js** 22.19.0
 - **Java** OpenJDK 23.0.1
-- **Ruby** 3.4.4 (with GC patch)
-- **Erlang/OTP** 28.0
+- **Ruby** 3.4.5 (with GC patch on full version)
+- **Erlang/OTP** 28.0.2
 - **Elixir** 1.18.4 (using OTP 27 binary for OTP 28 compatibility)
-- **Rust** 1.70.0
-- **C++** g++ 12.3.0
+- **Rust** 1.87.0
+- **C++** GCC 13 (g++-13) on Ubuntu 24.04
+
+### Lite Version (Dockerfile.lite)
+- Same languages and versions as Full version
+- Ruby without GC patch (standard build)
+- Optimized multi-stage build for smaller image size
+
+**Note**: All version information is defined in `toml/*.toml` configuration files, which serve as the single source of truth for language versions.
 
 ## Key Architecture Decisions
 
+### Build Strategy
+- **Full Version**: Single-stage build with all dependencies
+- **Lite Version**: Multi-stage build (builder + runtime stages) for optimized size
+  - Builder stage: Compiles languages from source
+  - Runtime stage: Only includes runtime dependencies and built artifacts
+
 ### Language Installation Methods
-- **Python**: Built from source with optimization flags
-- **Node.js**: Direct binary installation from nodejs.org
-- **Java**: OpenJDK binary from java.net
+- **Python**: Built from source with PGO (Profile-Guided Optimization) and optimization flags
+- **Node.js**: Precompiled binary installation from nodejs.org
+- **Java**: OpenJDK precompiled binary from java.net
 - **Ruby**: Built using ruby-build
+  - Full version: With GC patch for optimization
+  - Lite version: Standard build without patches
 - **Erlang/Elixir**: Built from source
-- **Rust**: Installed via asdf
-- **C++**: System package (g++-12)
+- **Rust**: Installed from official precompiled tarball (not asdf)
+- **C++**: System package (g++-13 from Ubuntu 24.04 repositories)
 
 ### Competitive Programming Libraries
-- **Python**: ac-library-python, sortedcontainers, NumPy, SciPy, PyTorch CPU
+- **Python**: ac-library-python, sortedcontainers, NumPy, SciPy, PyTorch CPU (full version)
 - **Java**: ac-library-java v2.0.0 (ac_library.jar)
 - **Ruby**: ac-library-rb, various gems for algorithms
 - **JavaScript**: ac-library-js, data-structure-typed, mathjs
+- **C++**: AC Library 1.6, Boost 1.88.0, Eigen3 3.4.0 (full version)
 - **All languages**: online-judge-tools (oj) and atcoder-cli
 
 ### Special Configurations
 - **Java execution**: Uses `/judge/java.sh` wrapper to set stack size dynamically
 - **Elixir**: Pre-built Mix release at `/judge/main` with EXLA and Nx dependencies
-- **Python**: Includes scientific computing stack (NumPy, Pandas, SciPy, etc.)
+- **Python**: Includes scientific computing stack (NumPy, Pandas, SciPy, etc.) in full version
 - **Architecture support**: x86_64 and aarch64 (ARM64) with conditional builds
+- **Optimization**: ccache enabled for faster recompilation
 
 ## File Structure for Language Updates
 
 When updating language versions or adding dependencies:
-- `python/freeze.txt`: Python package list
+- `toml/*.toml`: **Primary source of truth** for language versions and configurations
+  - `toml/cpython.toml`: Python version and packages
+  - `toml/js-node.toml`: Node.js version and npm packages
+  - `toml/ruby.toml`: Ruby version and gems
+  - `toml/erlang.toml`: Erlang/OTP version
+  - `toml/elixir-nx.toml`: Elixir version and Mix dependencies
+  - `toml/config.toml`: C++ compiler and library versions
+- `python/freeze.txt`: Python package list (full version)
 - `java/java.sh`: Java execution wrapper script
 - `elixir/`: Elixir project files (mix.exs, config.exs, main.ex)
-- `toml/`: Configuration files for various build tools
+- `rust/Cargo-lite.toml`: Rust dependencies for lite version
 
 ## Important Notes
 
@@ -67,4 +111,5 @@ When updating language versions or adding dependencies:
 - Locale: ja_JP.UTF-8
 - Environment variable `ATCODER=1` is set
 - The container is optimized for AtCoder's judge environment
-- Some C++ libraries (Boost, Eigen) are commented out in the Dockerfile but can be enabled if needed
+- Version information in this file should be kept in sync with `toml/*.toml` files
+- C++ libraries (Boost, Eigen, OR-Tools) are included in full version, optional in lite version


### PR DESCRIPTION
## Summary

Update CLAUDE.md documentation with the latest language versions and comprehensive container variant information.

## Changes

### Container Variants Section (New)
- Added detailed comparison between Full and Lite versions
- Documented size differences (~8-10GB vs ~3.86GB)
- Explained build strategies and use cases

### Updated Language Versions
- **Python**: 3.13.5 → 3.13.7
- **Node.js**: 22.16.0 → 22.19.0
- **Ruby**: 3.4.4 → 3.4.5
- **Erlang/OTP**: 28.0 → 28.0.2
- **Elixir**: 1.18.4 (no change, but clarified OTP compatibility)
- **Rust**: 1.70.0 → 1.87.0
- **C++**: g++ 12 → g++ 13 (Ubuntu 24.04 default)

### Build Strategy Section (New)
- Added `toml/*.toml` as the primary source of truth
- Emphasized configuration compliance requirements
- Documented build strategy differences between Full and Lite

### Corrected Technical Details
- Fixed Rust installation method: ~~asdf~~ → official precompiled tarball
- Added multi-stage build explanation for Lite version

### Enhanced File Structure
- Expanded `toml/*.toml` documentation with all configuration files
- Added detailed descriptions for each TOML file's purpose

## Verification

All version numbers verified from:
- `toml/cpython.toml` (Python 3.13.7)
- `toml/js-node.toml` (Node.js 22.19.0)
- `toml/ruby.toml` (Ruby 3.4.5)
- `toml/erlang.toml` (Erlang 28.0.2)
- `Dockerfile.lite` (Elixir 1.18.4, Rust 1.87.0)
- `Dockerfile` (GCC 13)