### PR TITLE
Add manifest creation job to build-staged workflow

### DIFF
--- a/.github/workflows/build-staged.yml
+++ b/.github/workflows/build-staged.yml
@@ -411,7 +411,10 @@ jobs:
   # Stage 5: Create multi-architecture manifests
   create-manifests:
     needs: [determine-strategy, build-lite, build-full]
-    if: needs.determine-strategy.outputs.is_main_branch == 'true'
+    if: |
+      always() &&
+      needs.determine-strategy.outputs.is_main_branch == 'true' &&
+      (needs.build-lite.result == 'success' || needs.build-full.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -430,7 +433,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest for lite-latest
-        if: needs.determine-strategy.outputs.build_lite == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_lite == 'true' &&
+          needs.build-lite.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -439,7 +444,9 @@ jobs:
             ${IMAGE}:lite-latest-arm64
 
       - name: Create manifest for full-latest
-        if: needs.determine-strategy.outputs.build_full == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_full == 'true' &&
+          needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -448,7 +455,9 @@ jobs:
             ${IMAGE}:full-latest-arm64
 
       - name: Create manifest for latest (points to full)
-        if: needs.determine-strategy.outputs.build_full == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_full == 'true' &&
+          needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -457,7 +466,9 @@ jobs:
             ${IMAGE}:latest-arm64
 
       - name: Create manifest for all (points to full)
-        if: needs.determine-strategy.outputs.build_full == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_full == 'true' &&
+          needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -466,7 +477,9 @@ jobs:
             ${IMAGE}:all-arm64
 
       - name: Create manifest for date tag (points to full)
-        if: needs.determine-strategy.outputs.build_full == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_full == 'true' &&
+          needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -475,7 +488,9 @@ jobs:
             ${IMAGE}:${{ steps.date.outputs.today }}-arm64
 
       - name: Create manifest for language update version lite
-        if: needs.determine-strategy.outputs.build_lite == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_lite == 'true' &&
+          needs.build-lite.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -484,7 +499,9 @@ jobs:
             ${IMAGE}:lite-latest-arm64
 
       - name: Create manifest for language update version full
-        if: needs.determine-strategy.outputs.build_full == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_full == 'true' &&
+          needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \
@@ -493,7 +510,9 @@ jobs:
             ${IMAGE}:full-latest-arm64
 
       - name: Create manifest for language update version (points to full)
-        if: needs.determine-strategy.outputs.build_full == 'true'
+        if: |
+          needs.determine-strategy.outputs.build_full == 'true' &&
+          needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
           docker buildx imagetools create \


### PR DESCRIPTION
## 概要

`build-staged.yml` に欠落していたマニフェスト作成ジョブを追加します。

## 背景

現在、`build-staged.yml` ワークフローでは各アーキテクチャ固有のイメージ（`latest-amd64`, `latest-arm64`）は正常にビルドされていますが、それらを統合したマルチアーキテクチャマニフェスト（`latest` タグ）が作成されていませんでした。

調査の結果、以前の `build-latest.yml`（現在は無効化）にはマニフェスト作成ジョブが存在していましたが、`build-staged.yml` への移行時にこのジョブがコピーされていなかったことが判明しました。

## 変更内容

### 1. マニフェスト作成ジョブの追加

`create-manifests` ジョブを追加:
- **条件**: main ブランチでのみ実行
- **作成するマニフェスト**:
  - `lite-latest` (lite ビルドが実行された場合)
  - `full-latest` (full ビルドが実行された場合)
  - `latest` (full を指す)
  - `all` (full を指す)
  - 日付ベースタグ（例: `20251025`、full を指す）

### 2. 言語アップデートバージョンタグの追加

`LANGUAGE_UPDATE_VERSION` 環境変数を追加し、言語バージョンセットを追跡できるようにしました。

**追加されるタグ**:
- `202510update-lite` - lite 版の言語アップデート
- `202510update-full` - full 版の言語アップデート
- `202510update` - メインタグ（full を指す）

**メリット**:
- 言語バージョンのセットを明示的に識別できる
- 特定の言語バージョンセットに戻すことが可能
- 日付タグ（ビルド日時）と区別できる

**運用**:
言語バージョン更新時に `LANGUAGE_UPDATE_VERSION` を変更（例: `202510update` → `202601update`）することで、新しいバージョンタグが自動的に作成されます。

## 効果

- `docker pull ghcr.io/smkwlab/atcoder-container:latest` で最新のマルチアーキテクチャイメージが取得できる
- アーキテクチャに応じて適切なイメージが自動選択される
- 言語アップデートのタイミングを明示的に管理できる
- 特定の言語バージョンセットに戻すことが可能

## テスト計画

- [ ] PR をマージして main ブランチでワークフローを実行
- [ ] マニフェストが正常に作成されることを確認
- [ ] `docker pull` で最新イメージが取得できることを確認
- [ ] 言語アップデートバージョンタグが作成されることを確認