### PR TITLE
Fix oj command shebang path in multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -345,7 +345,7 @@ ENV LANG="ja_JP.UTF-8" \
 COPY --from=builder /opt/python /usr/local/
 
 # Fix oj command shebang to point to the correct Python location
-RUN sed -i '1s|#!/opt/python/bin/python3.13|#!/usr/bin/env python3.13|' /usr/local/bin/oj
+RUN sed -i '1s|#!/opt/python/bin/python[0-9.]*|#!/usr/bin/env python3|' /usr/local/bin/oj
 
 COPY --from=builder /opt/ruby /opt/ruby
 COPY --from=builder /opt/erlang /usr/local/

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -248,7 +248,7 @@ ENV LANG="ja_JP.UTF-8" \
 COPY --from=builder /opt/python /usr/local/
 
 # Fix oj command shebang to point to the correct Python location
-RUN sed -i '1s|#!/opt/python/bin/python3.13|#!/usr/bin/env python3.13|' /usr/local/bin/oj
+RUN sed -i '1s|#!/opt/python/bin/python[0-9.]*|#!/usr/bin/env python3|' /usr/local/bin/oj
 
 COPY --from=builder /opt/ruby /opt/ruby
 COPY --from=builder /opt/erlang /usr/local/


### PR DESCRIPTION
Closes #47

## Problem

The `oj` command cannot execute in the runtime stage because its shebang points to the wrong Python path.

## Root Cause

The `oj` script installed by pip has shebang `#!/opt/python/bin/python3.13`, but in the multi-stage build:
- **Builder stage**: Python is installed at `/opt/python`
- **Runtime stage**: Python is copied to `/usr/local`

So the shebang path `/opt/python/bin/python3.13` doesn't exist in runtime.

## Solution

After copying Python to `/usr/local` in the runtime stage, fix the shebang:

```dockerfile
# Fix oj command shebang to point to the correct Python location
RUN sed -i '1s|#!/opt/python/bin/python3.13|#!/usr/bin/env python3.13|' /usr/local/bin/oj
```

Using `#!/usr/bin/env python3.13` is more portable and works correctly since `/usr/local/bin` is in PATH.

## Changes

- **Dockerfile**: Add shebang fix after copying Python
- **Dockerfile.lite**: Add shebang fix after copying Python

## Testing

The fix can be verified by:
```bash
docker run --rm ghcr.io/smkwlab/atcoder-container:latest head -1 /usr/local/bin/oj
# Should show: #!/usr/bin/env python3.13

docker run --rm ghcr.io/smkwlab/atcoder-container:latest oj --version
# Should execute successfully
```