### PR TITLE
Add jq and configure Java to use /judge directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
             g++-13 \
             wget \
             unzip \
+            jq \
             # Python build dependencies
             gdb \
             lcov \
@@ -427,7 +428,7 @@ RUN case "$(uname -m)" in \
 
 # AC Library for Java
 RUN wget -q https://github.com/ocha98/ac-library-java/releases/download/v2.0.0/ac_library23.jar && \
-    mv ac_library23.jar ac_library.jar
+    mv ac_library23.jar /judge/ac_library.jar
 
 # Java execution script
 COPY java/java.sh /judge/java.sh

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -21,6 +21,7 @@ RUN apt-get update && \
             g++-13 \
             wget \
             unzip \
+            jq \
             # Python build dependencies
             gdb \
             lcov \
@@ -307,7 +308,7 @@ RUN case "$(uname -m)" in \
 
 # AC Library for Java
 RUN wget -q https://github.com/ocha98/ac-library-java/releases/download/v2.0.0/ac_library23.jar && \
-    mv ac_library23.jar ac_library.jar
+    mv ac_library23.jar /judge/ac_library.jar
 
 # Java execution script
 COPY java/java.sh /judge/java.sh

--- a/java/java.sh
+++ b/java/java.sh
@@ -4,4 +4,5 @@ if [ "$1" -gt 1024 ]; then
 else
     stack_size="$1"
 fi
-java -Xss"$stack_size"M -DONLINE_JUDGE=true -cp ac_library.jar: Main
+work_dir="${2:-/judge}"
+java -Xss"$stack_size"M -DONLINE_JUDGE=true -cp "$work_dir"/ac_library.jar:"$work_dir": Main


### PR DESCRIPTION
## 概要

Issue #49 Phase 1 の実装です。Javaが`/judge`ディレクトリを使用するための準備を行います。

## 変更内容

### 1. `jq` のインストール
- Dockerfile と Dockerfile.lite の両方に `jq` を追加
- makefileで `contest.acc.json` からタスクURLを取得する際に必要

### 2. `ac_library.jar` の配置変更
- **変更前**: `/root/ac_library.jar`（カレントディレクトリ）
- **変更後**: `/judge/ac_library.jar`
- Judge環境と同じディレクトリ構成に統一

### 3. `java.sh` の更新
- 作業ディレクトリを第2引数で受け取れるように変更（デフォルト: `/judge`）
- classpath を `/judge/ac_library.jar:/judge:` に変更
- ACL（AtCoder Library）を引き続きサポート

```sh
# 変更前
java -Xss"$stack_size"M -DONLINE_JUDGE=true -cp ac_library.jar: Main

# 変更後
work_dir="${2:-/judge}"
java -Xss"$stack_size"M -DONLINE_JUDGE=true -cp "$work_dir"/ac_library.jar:"$work_dir": Main
```

## 期待される効果

1. ✅ **jq が利用可能**: makefileの全機能が動作
2. ✅ **Judge環境との一貫性**: `ac_library.jar` が `/judge/` に配置
3. ✅ **次フェーズの準備完了**: atcoder-env側でJavaを `/judge` ディレクトリで実行可能に

## 次のステップ（Phase 2）

atcoder-env リポジトリで以下を実装：
- `lib/.support/makefile` の Java セクション更新
- `/judge` でコンパイル・実行するように変更
- STRICT_MODE 分岐の削除

## 関連

- Resolves #49 (Phase 1)
- Related to #58 (言語のコンパイル方法の更新)