### PR TITLE
Add debug logging to diagnose version tag update issue

### DIFF
--- a/.github/workflows/build-staged.yml
+++ b/.github/workflows/build-staged.yml
@@ -509,10 +509,16 @@ jobs:
           needs.build-lite.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
+          echo "🔍 Creating manifest: ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}-lite"
+          echo "📦 Source images:"
+          docker buildx imagetools inspect ${IMAGE}:lite-latest-amd64 | head -10
+          docker buildx imagetools inspect ${IMAGE}:lite-latest-arm64 | head -10
           docker buildx imagetools create \
             -t ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}-lite \
             ${IMAGE}:lite-latest-amd64 \
             ${IMAGE}:lite-latest-arm64
+          echo "✅ Verifying created manifest:"
+          docker buildx imagetools inspect ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}-lite | head -10
 
       - name: Create manifest for language update version full
         if: |
@@ -520,10 +526,16 @@ jobs:
           needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
+          echo "🔍 Creating manifest: ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}-full"
+          echo "📦 Source images:"
+          docker buildx imagetools inspect ${IMAGE}:full-latest-amd64 | head -10
+          docker buildx imagetools inspect ${IMAGE}:full-latest-arm64 | head -10
           docker buildx imagetools create \
             -t ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}-full \
             ${IMAGE}:full-latest-amd64 \
             ${IMAGE}:full-latest-arm64
+          echo "✅ Verifying created manifest:"
+          docker buildx imagetools inspect ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}-full | head -10
 
       - name: Create manifest for language update version (points to full)
         if: |
@@ -531,7 +543,13 @@ jobs:
           needs.build-full.result == 'success'
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/atcoder-container
+          echo "🔍 Creating manifest: ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }}"
+          echo "📦 Source images:"
+          docker buildx imagetools inspect ${IMAGE}:latest-amd64 | head -10
+          docker buildx imagetools inspect ${IMAGE}:latest-arm64 | head -10
           docker buildx imagetools create \
             -t ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }} \
             ${IMAGE}:latest-amd64 \
             ${IMAGE}:latest-arm64
+          echo "✅ Verifying created manifest:"
+          docker buildx imagetools inspect ${IMAGE}:${{ env.LANGUAGE_UPDATE_VERSION }} | head -10


### PR DESCRIPTION
## 概要

Issue #53の調査・修正のため、`create-manifests`ジョブにデバッグログを追加します。

## 問題

PR #51マージ時、`202510update-lite`タグが作成されたものの、**古いdigest (`fefa7ce7...`) を指していた**ことが判明しました:

- ワークフローログでは"Create manifest for language update version lite"ステップが**成功**
- しかし作成されたタグが古いイメージを指していた
- 手動ビルド実行後、新しいdigest (`5ff65f06...`) を指すように更新された

## 変更内容

3つのmanifest作成ステップにデバッグログを追加:
1. `202510update-lite` 作成
2. `202510update-full` 作成  
3. `202510update` 作成

各ステップで:
- 📦 ソースイメージ（`lite-latest-amd64`/`lite-latest-arm64`等）のdigestを出力
- ✅ 作成されたmanifestのdigestを検証・出力

## 期待される効果

次回のビルドで、以下が確認できます:
- ソースイメージ（`*-latest-amd64`/`*-latest-arm64`）が正しい新しいdigestを指しているか
- 作成されたversion tagが正しいdigestを指しているか
- タグ作成が失敗している場合、エラーメッセージが表示される

## テスト計画

このPRをマージ後:
1. 次のPRマージ時にワークフローログを確認
2. デバッグログから根本原因を特定
3. 必要に応じて追加の修正を実装

resolve #53