### PR TITLE
Add jq to runtime stage in both Dockerfile and Dockerfile.lite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -303,6 +303,7 @@ RUN apt-get update && \
             wget \
             unzip \
             xz-utils \
+            jq \
             # Runtime libraries only (no -dev packages)
             libssl3t64 \
             libreadline8t64 \

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -212,6 +212,7 @@ RUN apt-get update && \
             wget \
             unzip \
             xz-utils \
+            jq \
             # Runtime libraries only (no -dev packages)
             libssl3t64 \
             libreadline8t64 \


### PR DESCRIPTION
## Summary

Adds `jq` to the runtime stage in both `Dockerfile` and `Dockerfile.lite` to make the base images self-contained and functional for atcoder-env makefile.

Resolves #56

## Problem

Currently, `jq` is only installed in the **builder stage** of both Dockerfiles, but multi-stage builds do not carry over packages from builder to runtime. This means:

- ❌ Final images do not include `jq`
- ❌ atcoder-env makefile fails without workaround
- ❌ Users must install `jq` separately in `.devcontainer/Dockerfile`

## Root Cause

Multi-stage Docker builds use separate `FROM` statements for each stage. The runtime stage starts fresh from `ubuntu:24.04`, so packages installed in the builder stage are not available unless explicitly copied or re-installed.

**Current state:**
- Line 23 (Dockerfile) / Line 24 (Dockerfile.lite): `jq` in **builder stage** ✅
- Line 287 (Dockerfile) / Line 196 (Dockerfile.lite): **runtime stage** begins with fresh Ubuntu
- **Missing**: `jq` not installed in runtime stage ❌

## Solution

Add `jq` to the runtime stage package installation list, placing it with other utility tools:

### Dockerfile Changes
```diff
             wget \
             unzip \
             xz-utils \
+            jq \
             # Runtime libraries only (no -dev packages)
```
**Location**: Line 306 (after `xz-utils`)

### Dockerfile.lite Changes  
```diff
             wget \
             unzip \
             xz-utils \
+            jq \
             # Runtime libraries only (no -dev packages)
```
**Location**: Line 215 (after `xz-utils`)

## Why jq is Required

The makefile in atcoder-env uses `jq` to parse `contest.acc.json`:

**lib/.support/makefile (line 150):**
```makefile
TASK_URL:=$$(cat ../contest.acc.json|jq -r ".tasks|map(select(.directory.path==\"$(TASK)\"))[]|.url")
```

This is critical for:
- `oj dl` - Downloading test cases from AtCoder
- `make open` / `make web` - Opening task pages in browser

Without `jq`, these makefile targets fail with "command not found" errors.

## Impact

### Image Size
- `jq` binary: ~200KB (minimal impact)
- No additional dependencies required

### Benefits
1. **Self-contained images**: Base images provide all required tools
2. **Consistency**: Both lite and full versions include the same core utilities
3. **Simplifies downstream**: atcoder-env can remove redundant jq installation
4. **Proper architecture**: Runtime tools in runtime stage, build tools in builder stage

### Affected Projects
- ✅ **atcoder-env**: Can now remove jq installation from `.devcontainer/Dockerfile`
- ✅ **Users**: No longer need manual jq installation

## Testing Plan

After merge and image rebuild:
1. Pull new image: `docker pull ghcr.io/smkwlab/atcoder-container:202510update-lite`
2. Verify jq exists: `docker run --rm ghcr.io/smkwlab/atcoder-container:202510update-lite which jq`
3. Test in atcoder-env: Remove jq from `.devcontainer/Dockerfile` and verify makefile works

## Related

- Blocked PR: smkwlab/atcoder-env#86 (Remove redundant jq installation)
- Related Issue: smkwlab/atcoder-env#85 (Investigation of jq necessity)
- Original commit: c54140f (added jq to builder stage only)

## Risk Assessment

**Low Risk:**
- Small package with no complex dependencies
- Already present in builder stage, just adding to runtime
- Used by existing makefile, so functionality is proven
- Minimal size impact (~200KB)