### PR TITLE
Add aclogin tool for AtCoder authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,8 +134,9 @@ RUN /opt/python/bin/python3.13 -m pip install \
     torch==2.8.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
     /opt/python/bin/python3.13 -m pip install ortools==9.14.6206
 
-# Install online-judge-tools
+# Install online-judge-tools and aclogin
 RUN /opt/python/bin/python3.13 -m pip install online-judge-tools==11.5.1
+RUN /opt/python/bin/python3.13 -m pip install aclogin
 RUN /opt/python/bin/python3.13 -m pip cache purge
 
 # Build Erlang from source

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -92,6 +92,7 @@ RUN /opt/python/bin/python3.13 -m pip install \
     pytz==2025.1 \
     typing_extensions==4.12.2
 RUN /opt/python/bin/python3.13 -m pip install online-judge-tools==11.5.1
+RUN /opt/python/bin/python3.13 -m pip install aclogin
 RUN /opt/python/bin/python3.13 -m pip cache purge
 
 # Build Erlang from source


### PR DESCRIPTION
## Summary

AtCoder の CAPTCHA/Cloudflare 導入により、\`acc\` と \`oj\` の自動ログインができなくなった問題に対応するため、\`aclogin\` ツールを追加しました。

## Changes

- **Dockerfile**: \`aclogin\` のインストールを追加
- **Dockerfile.lite**: \`aclogin\` のインストールを追加

## aclogin について

- GitHub: https://github.com/key-moon/aclogin
- インストール: \`pip install aclogin\`
- 機能: ブラウザから手動取得した \`REVEL_SESSION\` Cookie を使用して \`oj\` / \`acc\` にログイン

## Phase 2 について

このPRはPhase 1（イメージへのツール追加）です。Phase 2（atcoder-envでの対応）は、このイメージがビルド・公開された後に実施します：

- \`.postCreateContainer.sh\` の修正
- Cookie取得ガイドの実装
- ドキュメント作成

Related to smkwlab/atcoder-env#93