### PR TITLE
Add build timestamp to container-info.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -461,7 +461,8 @@ RUN apt-get update && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 90 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
 # Create info file
-RUN echo 'AtCoder Full 2025: Py3.13.7 Node22.19 Java23.0.1 Ruby3.4.5 Erlang28.0.2 Elixir1.18.4 Rust1.87 C++GCC13 PHP8.4.12+JIT | ML: NumPy SciPy PyTorch pandas | C++: ACLib Boost1.83 Eigen LibTorch | or-tools' > /usr/local/share/container-info.txt
+RUN echo 'AtCoder Full 2025: Py3.13.7 Node22.19 Java23.0.1 Ruby3.4.5 Erlang28.0.2 Elixir1.18.4 Rust1.87 C++GCC13 PHP8.4.12+JIT | ML: NumPy SciPy PyTorch pandas | C++: ACLib Boost1.83 Eigen LibTorch | or-tools' > /usr/local/share/container-info.txt && \
+    echo "Built: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> /usr/local/share/container-info.txt
 
 # Set final working directory
 WORKDIR /root

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -341,7 +341,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Create info file
-RUN echo 'AtCoder Lite 2025: Py3.13.7 Node22.19 Java23.0.1 Ruby3.4.5 Erlang28.0.2 Elixir1.18.4 Rust1.87 C++GCC13 PHP8.4.12+JIT | C++: ACLib Eigen' > /usr/local/share/container-info.txt
+RUN echo 'AtCoder Lite 2025: Py3.13.7 Node22.19 Java23.0.1 Ruby3.4.5 Erlang28.0.2 Elixir1.18.4 Rust1.87 C++GCC13 PHP8.4.12+JIT | C++: ACLib Eigen' > /usr/local/share/container-info.txt && \
+    echo "Built: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> /usr/local/share/container-info.txt
 
 # Set final working directory
 WORKDIR /root


### PR DESCRIPTION
## Summary

Add ISO 8601 UTC timestamp to `/usr/local/share/container-info.txt` for debugging and troubleshooting support.

## Changes

- **Dockerfile.lite** (line 344): Add build timestamp as second line
- **Dockerfile** (line 464): Add build timestamp as second line

## Example Output

```
AtCoder Lite 2025: Py3.13.7 Node22.19 Java23.0.1 Ruby3.4.5 Erlang28.0.2 Elixir1.18.4 Rust1.87 C++GCC13 PHP8.4.12+JIT | C++: ACLib Eigen
Built: 2025-01-29T13:45:32Z
```

## Benefits

1. **Troubleshooting**: Users can identify which build they are using
2. **Debugging**: Build timestamp can be shared when reporting issues
3. **Cache verification**: Easier to determine if image is up-to-date
4. **Standard format**: ISO 8601 UTC format for machine parsing

## Verification

Users can check build timestamp with:
```bash
cat /usr/local/share/container-info.txt
```

Fixes #65