### PR TITLE
Fix aclogin shebang path for runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,8 @@ RUN /opt/python/bin/python3.13 -m pip install \
 
 # Install online-judge-tools and aclogin
 RUN /opt/python/bin/python3.13 -m pip install online-judge-tools==11.5.1
-RUN /opt/python/bin/python3.13 -m pip install aclogin
+RUN /opt/python/bin/python3.13 -m pip install aclogin && \
+    sed -i '1s|^#!/opt/python/bin/python3.13|#!/usr/bin/env python3|' /opt/python/bin/aclogin
 RUN /opt/python/bin/python3.13 -m pip cache purge
 
 # Build Erlang from source

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -92,7 +92,8 @@ RUN /opt/python/bin/python3.13 -m pip install \
     pytz==2025.1 \
     typing_extensions==4.12.2
 RUN /opt/python/bin/python3.13 -m pip install online-judge-tools==11.5.1
-RUN /opt/python/bin/python3.13 -m pip install aclogin
+RUN /opt/python/bin/python3.13 -m pip install aclogin && \
+    sed -i '1s|^#!/opt/python/bin/python3.13|#!/usr/bin/env python3|' /opt/python/bin/aclogin
 RUN /opt/python/bin/python3.13 -m pip cache purge
 
 # Build Erlang from source


### PR DESCRIPTION
## Summary

Fix the shebang in aclogin to use `/usr/bin/env python3` instead of the builder stage path `/opt/python/bin/python3.13`. This ensures aclogin works correctly in the runtime stage.

## Problem

Users encountered the following error when trying to run aclogin:
```bash
root@2cb3c0aa783c:~# aclogin
bash: /usr/local/bin/aclogin: cannot execute: required file not found
```

## Root Cause

1. aclogin was installed in builder stage with Python at `/opt/python/bin/python3.13`
2. The shebang was set to `#!/opt/python/bin/python3.13`
3. In runtime stage, `/opt/python` is copied to `/usr/local/`
4. But the shebang still pointed to non-existent `/opt/python/bin/python3.13`

## Changes

- **Dockerfile.lite** line 95-96: Add sed command to fix shebang after install
- **Dockerfile** line 139-140: Add sed command to fix shebang after install

```dockerfile
RUN /opt/python/bin/python3.13 -m pip install aclogin && \
    sed -i '1s|^#!/opt/python/bin/python3.13|#!/usr/bin/env python3|' /opt/python/bin/aclogin
```

## Benefits

1. ✅ aclogin command execution without "cannot execute" errors
2. ✅ Automatic login prompts in `.postCreateContainer.sh` work correctly
3. ✅ Users can manually run `aclogin` when needed

## Verification

After building the image with this fix:
```bash
docker exec container_name aclogin --help
```

Should display aclogin help message instead of "cannot execute" error.

Fixes #67