### PR TITLE
Remove Elixir template main.ex to avoid module conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -360,6 +360,9 @@ COPY --from=builder /opt/elixir /usr/local/
 COPY --from=builder /opt/elixir-project /judge/
 COPY --from=builder /home/runner/.mix /root/.mix
 
+# Remove Elixir template main.ex to avoid module conflict with user's Main.ex
+RUN rm -f /judge/main/lib/main.ex
+
 # Copy LibTorch (Full version - x86_64 only, but copy empty dir for ARM64)
 COPY --from=builder /opt/libtorch /usr/local/libtorch
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -263,6 +263,9 @@ COPY --from=builder /opt/elixir /usr/local/
 COPY --from=builder /opt/elixir-project /judge/
 COPY --from=builder /home/runner/.mix /root/.mix
 
+# Remove Elixir template main.ex to avoid module conflict with user's Main.ex
+RUN rm -f /judge/main/lib/main.ex
+
 # Set up paths and library paths
 ENV PATH=/opt/ruby/bin:/usr/local/bin:$PATH \
     LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \


### PR DESCRIPTION
## 目的

コンテナイメージビルド時に`/judge/main/lib/main.ex`を削除し、ユーザーの`Main.ex`とのモジュール競合を根本的に解決します。

Resolves #69

## 問題

現在のコンテナイメージには`/judge/main/lib/main.ex`というテンプレートファイルが含まれており、ユーザーの`Main.ex`と同じ`Main`モジュールを定義するため競合が発生していました。

### 現状の回避策

atcoder-env側で以下の回避策を実装済みです（PR #111）：
- `.postCreateContainer.sh`で`main.ex`を削除
- makefileでElixirのビルド時にエラーメッセージが`Main.ex`の行番号を正確に表示

## 解決策

### 変更内容

両バージョンのDockerfileに`main.ex`削除コマンドを追加：

**Dockerfile.lite（267行目）**:
\`\`\`dockerfile
# Remove Elixir template main.ex to avoid module conflict with user's Main.ex
RUN rm -f /judge/main/lib/main.ex
\`\`\`

**Dockerfile（364行目）**:
\`\`\`dockerfile
# Remove Elixir template main.ex to avoid module conflict with user's Main.ex
RUN rm -f /judge/main/lib/main.ex
\`\`\`

### 配置場所

Elixirプロジェクトがbuilderからコピーされた直後に削除：
- Dockerfile.lite: `COPY --from=builder /opt/elixir-project /judge/` の直後
- Dockerfile: `COPY --from=builder /opt/elixir-project /judge/` の直後

## メリット

1. ✅ **責務の明確化**: イメージ側の問題をイメージ側で解決
2. ✅ **シンプルな運用**: atcoder-env側の回避策が冗長になるが、後方互換性は維持
3. ✅ **将来的な保守性**: イメージとenv側の依存関係が減る
4. ✅ **クリーンな初期状態**: 新規ユーザーは最初からクリーンな環境を取得

## 影響範囲

- ✅ **破壊的変更なし**: atcoder-envの回避策（`.postCreateContainer.sh`での削除）が引き続き動作
- ✅ **既存ユーザーへの影響なし**: `.postCreateContainer.sh`で既に削除済み
- ✅ **新規ユーザーへのメリット**: よりクリーンな初期状態
- ✅ **両バージョン対応**: Lite版とFull版の両方で一貫した動作

## 関連情報

- Issue #69: https://github.com/smkwlab/atcoder-container/issues/69
- atcoder-env PR #111: https://github.com/smkwlab/atcoder-env/pull/111
- 問題の発見経緯: atcoder-envのmakefileリファクタリング中にElixirのモジュール競合を発見