### PR TITLE
Document AC Library support by language

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | ライブラリ | ライト版 | フル版 |
 |------------|----------|--------|
 | 基本科学計算 (NumPy, SciPy等) | ✅ | ✅ |
-| AC Library (各言語) | ✅ | ✅ |
+| AC Library | ✅ | ✅ |
 | online-judge-tools | ✅ | ✅ |
 | atcoder-cli | ✅ | ✅ |
 | PyTorch | ❌ | ✅ |
@@ -46,6 +46,16 @@
 | torch-rb (Ruby) | ❌ | ✅ |
 | scikit-learn | ❌ | ✅ |
 | EXLA/Nx (Elixir) | ❌ | ✅ |
+
+### AC Library サポート状況
+
+AtCoder公式の[AC Library](https://atcoder.github.io/ac-library/)を以下の言語で利用可能：
+
+- **C++**: [AC Library 1.6](https://github.com/atcoder/ac-library)
+- **Python**: [ac-library-python](https://github.com/not522/ac-library-python)
+- **Java**: [ac-library-java 2.0.0](https://github.com/ocha98/ac-library-java)
+- **Ruby**: [ac-library-rb 1.2.0](https://github.com/universato/ac-library-rb)
+- **JavaScript**: [ac-library-js 0.1.1](https://github.com/pepsin92/ac-library-js)
 
 ## ビルド方法
 


### PR DESCRIPTION
## 変更内容

README.mdにAC Libraryのサポート状況を言語別に明記しました。

### 追加したセクション

```markdown
### AC Library サポート状況

AtCoder公式のAC Libraryを以下の言語で利用可能：

- C++: AC Library 1.6
- Python: ac-library-python
- Java: ac-library-java 2.0.0
- Ruby: ac-library-rb 1.2.0
- JavaScript: ac-library-js 0.1.1
```

### その他の変更

- 比較表の「AC Library (各言語)」→「AC Library」に変更（具体的な対応言語は別セクションで説明）

## 背景

従来の表記「AC Library (各言語)」では、どの言語がサポートされているか不明確でした。ユーザーがDockerfileを確認しなくても、サポート言語とバージョンが分かるようにしました。

## 検証方法

Dockerfileから各言語のAC Library実装を確認：

- **C++**: Line 215-220（AC Library 1.6をダウンロード）
- **Python**: Line 121（ac-library-python）
- **Java**: Line 435-437（ac-library-java v2.0.0）
- **Ruby**: Line 167（ac-library-rb 1.2.0）
- **JavaScript**: Line 411（ac-library-js 0.1.1）

## 影響範囲

- ドキュメントのみの変更
- コードへの影響なし