### PR TITLE
Fix auto-skip detection in build-staged.yml

### DIFF
--- a/.github/workflows/build-staged.yml
+++ b/.github/workflows/build-staged.yml
@@ -73,8 +73,12 @@ jobs:
           echo "Commit message: $COMMIT_MESSAGE"
 
           # Detect changed files for auto-skip detection
+          # For pull_request events, GitHub Actions checks out a synthetic merge commit
+          # where HEAD^1 is the base (main) and HEAD^2 is the PR head. The PR's own
+          # changes are the diff from HEAD^1 to HEAD^2, NOT from HEAD^2 to HEAD
+          # (the latter only reflects changes that landed on base after the PR branched).
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            CHANGED_FILES=$(git diff --name-only HEAD^2 HEAD 2>/dev/null || git diff --name-only HEAD^ HEAD 2>/dev/null || echo "")
+            CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD^2 2>/dev/null || git diff --name-only HEAD^ HEAD 2>/dev/null || echo "")
           else
             CHANGED_FILES=$(git diff --name-only HEAD^ HEAD 2>/dev/null || echo "")
           fi

--- a/.github/workflows/build-staged.yml
+++ b/.github/workflows/build-staged.yml
@@ -72,13 +72,19 @@ jobs:
           fi
           echo "Commit message: $COMMIT_MESSAGE"
 
-          # Detect changed files for auto-skip detection
-          # For pull_request events, GitHub Actions checks out a synthetic merge commit
-          # where HEAD^1 is the base (main) and HEAD^2 is the PR head. The PR's own
-          # changes are the diff from HEAD^1 to HEAD^2, NOT from HEAD^2 to HEAD
-          # (the latter only reflects changes that landed on base after the PR branched).
+          # Detect changed files for auto-skip detection.
+          # For pull_request events, GitHub Actions checks out a synthetic merge
+          # commit where HEAD^1 is the base (main) and HEAD^2 is the PR head.
+          # Diffing HEAD^1 against HEAD (the merge result) gives exactly what this
+          # PR would introduce on top of the current base; this avoids two failure
+          # modes of the previous logic:
+          #   - HEAD^2..HEAD returned base-side changes since the PR branched,
+          #     so non-doc PRs were misclassified as docs-only.
+          #   - HEAD^1..HEAD^2 would, if main has advanced since the PR branched,
+          #     surface those base-only changes as PR-side deletions and
+          #     misclassify a docs-only PR as needing a build.
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD^2 2>/dev/null || git diff --name-only HEAD^ HEAD 2>/dev/null || echo "")
+            CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD 2>/dev/null || git diff --name-only HEAD^ HEAD 2>/dev/null || echo "")
           else
             CHANGED_FILES=$(git diff --name-only HEAD^ HEAD 2>/dev/null || echo "")
           fi


### PR DESCRIPTION
resolve #80

## Summary

`build-staged.yml` の auto-skip 検出が、PR の差分ではなく「PR 分岐後に base 側に追加された差分」を見ていたため、ほぼ全ての PR で `DOCS_ONLY=true` と誤判定され、Dockerfile / TOML / yaml の変更すらビルドがスキップされていました。

`git diff` の比較対象を **base から merge commit (= 本 PR がテストする対象そのもの)** に変更します。

## Root cause

GitHub Actions が `pull_request` イベントでチェックアウトする synthetic merge commit では:

- `HEAD` = merge commit (base と PR head を合成)
- `HEAD^1` = base (main)
- `HEAD^2` = PR head

旧コード `git diff HEAD^2 HEAD` は **PR head から merge commit への差分**、つまり「base 側が PR 分岐後に追加した変更」を返します。main が静止している間は空 (もしくは docs-only) になり、PR がどんな変更をしていても `DOCS_ONLY=true` に倒れていました。

## Fix

`git diff HEAD^1 HEAD` (base → merge commit) に変更しました。これは「merge を取り込んだ後にレポジトリがどう変わるか」=「PR が base の上に追加する内容」を直接表します。

### なぜ `HEAD^1 HEAD^2` ではなく `HEAD^1 HEAD` なのか

初期実装では `HEAD^1 HEAD^2` (base → PR head) を採用していましたが、レビュー過程で次のエッジケースが指摘されました:

- PR 分岐後に main が `new.cpp` を追加
- `HEAD^1` (current main) には `new.cpp` あり
- `HEAD^2` (PR head, frozen) には `new.cpp` なし
- `git diff HEAD^1 HEAD^2` で `new.cpp` が **削除として** 検出される
- docs-only な PR が「.cpp の変更を含む」と誤判定 → 不要なビルド

`HEAD^1 HEAD` なら merge 結果に base のすべての変更が既に取り込まれているので、上記のノイズが入りません。コミット d060b0e で改善しました。

## Changes

- `.github/workflows/build-staged.yml` L77: diff の比較対象を `HEAD^2 HEAD` → `HEAD^1 HEAD` に修正
- 同じ過ちが繰り返されないよう、2 つの失敗モード (`HEAD^2..HEAD` 旧バグ / `HEAD^1..HEAD^2` のエッジケース) を説明するコメントを追加

`fetch-depth: 2` のまま動作します (merge commit と 2 つの親はすべてフェッチ済み)。

## Verification

### CI run (commit d060b0e)

[run 25705473206](https://github.com/smkwlab/atcoder-container/actions/runs/25705473206) が **32m8s で success**。`[build-all]` タグなしで Lite ビルドが正常起動し、判定ログで以下を確認できました:

```
Build required due to: .github/workflows/build-staged.yml
Documentation-only change: false
```

### 過去の検証 (commit ee59bcc, 初期実装の HEAD^1 HEAD^2)

[run 25669561988](https://github.com/smkwlab/atcoder-container/actions/runs/25669561988) が 52m49s で success。base が進んでいない単純ケースでは旧実装でも動作していたが、エッジケース耐性のため d060b0e で更に改善しました。

## Test plan

- [x] CI run の `determine-strategy` ログで `Documentation-only change: false` を確認
- [x] Lite ビルドが正常に走る (`[build-all]` タグなしで)
- [x] PR build verification コメントが投稿される

## 影響範囲

- 既に merge 済みの過去 PR には影響なし
- 今後の PR では auto-skip が**本来の意図通り**動作 (docs-only のみスキップ、それ以外はビルド)
- CLAUDE.md に記載されている auto-skip 仕様に実装が追従する